### PR TITLE
Adding crac build command

### DIFF
--- a/scripts/super_important_script.sh
+++ b/scripts/super_important_script.sh
@@ -27,3 +27,17 @@ function downloadRAM
     printf "\b"
     echo  "Done"
 }
+
+function crac
+{
+    i=1
+    sp="/-\|"
+    echo -n ' '
+    echo -n 'Automatically compiling your mixed-ROS workspace '
+    seconds=5; date1=$((`date +%s` + $seconds));
+    while [ "$date1" -ne `date +%s` ]; do
+        printf "\b${sp:i++%${#sp}:1}"
+    done
+    printf "\b"
+    echo  "Completed Successfully"
+}


### PR DESCRIPTION
Just realized we didn't add the build script. To do a simple quick build, type:

```
crac build --log-level info -i -v --event-handlers console_direct+ --packages-select roscpp 
```